### PR TITLE
Fixes :appname option (typo)

### DIFF
--- a/lib/mongo/mongo_db_connection.ex
+++ b/lib/mongo/mongo_db_connection.ex
@@ -137,7 +137,7 @@ defmodule Mongo.MongoDBConnection do
   end
 
   defp hand_shake(opts, state) do
-    wire_version(state, driver(opts[:appyname] || "My killer app"))
+    wire_version(state, driver(opts[:appname] || "My killer app"))
   end
 
   defp driver(appname) do


### PR DESCRIPTION
This may be the tiniest pull request ever, but I was a bit annoyed seeing the `"My killer app"` string when establishing the connection to MongoDB (I want to use my own funny sentence :wink:). Even when correctly configuring the documented `:appname` option it kept showing.

It turns out the issue was a simply a typo in `Mongo.MongoDBConnection.hand_shake/2` function.

I couldn't find any test covering this configuration option, so this pull request is being offered without the test coverage. If you do have any test coverage for that, please give some directions and I'll add the tests.