### PR TITLE
Add custom mongo.encoder protocol

### DIFF
--- a/lib/bson/encoder.ex
+++ b/lib/bson/encoder.ex
@@ -105,7 +105,11 @@ defmodule BSON.Encoder do
         {key, value}, {_, acc} ->
           {key_type, key} = key(key)
           type = type(value)
-          value = encode(value)
+          value =
+            if Mongo.Encoder.impl_for(value),
+              do: value |> Mongo.Encoder.encode() |> encode(),
+              else: value |> encode()
+
           {key_type, [acc, type, key, value]}
       end)
 

--- a/lib/mongo.ex
+++ b/lib/mongo.ex
@@ -1340,9 +1340,13 @@ defmodule Mongo do
   defp assert_single_doc!(doc) when is_map(doc), do: :ok
   defp assert_single_doc!([]), do: :ok
   defp assert_single_doc!([{_, _} | _]), do: :ok
-  defp assert_single_doc!(other), do: raise ArgumentError, "expected single document, got: #{inspect other}"
+  defp assert_single_doc!(other) do
+    unless Mongo.Encoder.impl_for(other),
+      do: raise(ArgumentError, "expected single document, got: #{inspect(other)}"),
+      else: :ok
+  end
 
-  defp assert_many_docs!([first | _]) when not is_tuple(first), do: :ok
+  defp assert_many_docs!(docs) when is_list(docs), do: Enum.all?(docs, &assert_single_doc!/1) && :ok
   defp assert_many_docs!(other), do: raise ArgumentError, "expected list of documents, got: #{inspect other}"
 
   defp defaults(opts) do

--- a/lib/mongo/encoder.ex
+++ b/lib/mongo/encoder.ex
@@ -1,0 +1,10 @@
+defprotocol Mongo.Encoder do
+  @fallback_to_any false
+
+  @spec encode(t) :: map()
+  def encode(value)
+end
+
+defimpl Mongo.Encoder, for: Map do
+  def encode(v), do: v
+end

--- a/lib/utils.ex
+++ b/lib/utils.ex
@@ -1,8 +1,10 @@
 defmodule Mongo.Utils do
 
   def assign_ids(list) when is_list(list) do
-    Enum.map(list, &assign_id/1)
-    |> Enum.unzip
+    list
+    |> Enum.map(&Mongo.Encoder.encode/1)
+    |> Enum.map(&assign_id/1)
+    |> Enum.unzip()
   end
 
   defp assign_id(%{_id: id} = map) when id != nil,  do: {id, map}

--- a/mix.exs
+++ b/mix.exs
@@ -20,7 +20,8 @@ defmodule Mongodb.Mixfile do
        plt_add_apps: [:logger, :connection, :db_connection, :mix, :elixir, :ssl, :public_key],
        plt_add_deps: :transitive,
        plt_core_path: "plt_core_path"
-     ]
+     ],
+     consolidate_protocols: Mix.env() != :test
    ]
   end
 

--- a/test/mongo/encoder_text.exs
+++ b/test/mongo/encoder_text.exs
@@ -1,0 +1,121 @@
+defmodule Mongo.EncoderTest do
+  use MongoTest.Case, async: false
+  alias Mongo
+
+  setup_all do
+    assert {:ok, pid} = Mongo.TestConnection.connect
+    Mongo.drop_database(pid)
+    {:ok, [pid: pid]}
+  end
+
+  defmodule CustomStructWithoutProtocol do
+    @fields [:a, :b, :c, :id]
+    @enforce_keys @fields
+    defstruct @fields
+  end
+
+  defmodule CustomStruct do
+    @fields [:a, :b, :c, :id]
+    @enforce_keys @fields
+    defstruct @fields
+
+    defimpl Mongo.Encoder do
+      def encode(%{a: a, b: b, id: id}) do
+        %{
+          _id: id,
+          a: a,
+          b: b,
+          custom_encoded: true
+        }
+      end
+    end
+  end
+
+  test "insert encoded struct with protocol", c do
+    coll = unique_collection()
+
+    struct_to_insert = %CustomStruct{a: 10, b: 20, c: 30, id: "5ef27e73d2a57d358f812001"}
+
+    assert {:ok, _} = Mongo.insert_one(c.pid, coll, struct_to_insert, [])
+
+    assert [
+      %{
+                  "a" => 10,
+                  "b" => 20,
+                  "custom_encoded" => true,
+                  "_id" => "5ef27e73d2a57d358f812001"
+                }
+              ] = Mongo.find(c.pid, coll, %{}) |> Enum.to_list()
+  end
+
+  test "insert encoded struct without protocol", c do
+    coll = unique_collection()
+
+    struct_to_insert = %CustomStructWithoutProtocol{a: 10, b: 20, c: 30, id: "x"}
+
+    assert [%{"a" => 10, "b" => 20, "c" => 30, "id" => "x"}] = Mongo.find(c.pid, coll, %{}) |> Enum.to_list()
+  end
+
+  defimpl Mongo.Encoder, for: Function do
+    def encode(_), do: %{fun: true, _id: "5ef27e73d2a57d358f812002"}
+  end
+
+  test "insert encoded function to db", c do
+    coll = unique_collection()
+
+    fun_to_insert = & &1
+
+    assert {:ok, _} = Mongo.insert_one(c.pid, coll, fun_to_insert, [])
+
+    assert [%{"fun" => true, "_id" => "5ef27e73d2a57d358f812002"}]
+        = Mongo.find(c.pid, coll, %{}) |> Enum.to_list()
+  end
+
+  test "update with encoded struct in db with protocol", c do
+    coll = unique_collection()
+
+    struct_to_insert = %CustomStruct{a: 10, b: 20, c: 30, id: "5ef27e73d2a57d358f812001"}
+
+    assert {:ok, _} = Mongo.insert_one(c.pid, coll, struct_to_insert, [])
+
+    struct_to_change = %CustomStruct{a: 100, b: 200, c: 300, id: "5ef27e73d2a57d358f812001"}
+
+    assert {:ok, _} =
+             Mongo.update_one(c.pid, coll, %{_id: "5ef27e73d2a57d358f812001"}, %{
+               "$set": struct_to_change
+             })
+
+    assert [
+                %{
+                  "a" => 100,
+                  "b" => 200,
+                  "custom_encoded" => true,
+                  "_id" => "5ef27e73d2a57d358f812001"
+                }
+              ] = Mongo.find(c.pid, coll, %{}) |> Enum.to_list()
+  end
+
+  test "upsert with encoded struct in db with protocol", c do
+    coll = unique_collection()
+
+    struct_to_change = %CustomStruct{a: 100, b: 200, c: 300, id: "5ef27e73d2a57d358f812001"}
+
+    assert {:ok, _} =
+             Mongo.update_one(
+               c.pid,
+               coll,
+               %{_id: "5ef27e73d2a57d358f812001"},
+               %{"$set": struct_to_change},
+               upsert: true
+             )
+
+    assert  [
+                %{
+                  "a" => 100,
+                  "b" => 200,
+                  "custom_encoded" => true,
+                  "_id" => "5ef27e73d2a57d358f812001"
+                }
+              ] = Mongo.find(c.pid, coll, %{}) |> Enum.to_list()
+  end
+end

--- a/test/mongo_test.exs
+++ b/test/mongo_test.exs
@@ -3,6 +3,10 @@ defmodule Mongo.Test do
 
   defmodule TestUser do
     defstruct name: "John", age: 27
+
+    defimpl Mongo.Encoder do
+      def encode(m), do: Map.drop(m, [:__struct__])
+    end
   end
 
   setup_all do
@@ -599,8 +603,8 @@ defmodule Mongo.Test do
  end
 
   test "create collection", c do
-
     coll = unique_name()
+
     assert nil == Mongo.show_collections(c.pid) |> Enum.find(fn c -> c == coll end)
     assert :ok == Mongo.create(c.pid, coll)
     assert nil != Mongo.show_collections(c.pid) |> Enum.find(fn c -> c == coll end)
@@ -608,8 +612,8 @@ defmodule Mongo.Test do
   end
 
   test "save struct", c do
-
     coll = unique_name()
+
     value = %TestUser{}
     {:ok, %Mongo.InsertOneResult{inserted_id: id}} = Mongo.insert_one(c.pid, coll, value)
     assert id != nil


### PR DESCRIPTION
Hi,

This PR adds a feature: Mongo.Encoder protocol.

In our project, we very often spot a case when we need to insert map, generated from some struct into the mongo database. With that PR, instead of writing a custom glue code, we can simply implement Mongo.Encoder protocol. Which in turns results in clearer, more idiomatic Elixir code.

This however results in a small incompatibility with previous version - since it's now impossible to insert struct without `Mongo.Encoder` protocol. 