### PR TITLE
[wip] mark servers unknown on not master errors

### DIFF
--- a/lib/mongo/session.ex
+++ b/lib/mongo/session.ex
@@ -473,7 +473,10 @@ defmodule Mongo.Session do
           |> ReadPreference.add_read_preference(opts)
           |> filter_nils()
 
-    {:keep_state_and_data, {:ok, conn, cmd}}
+    {host, port} = Mongo.MongoDBConnection.Utils.hostname_port(opts)
+    address = "#{host}:#{port}"
+
+    {:keep_state_and_data, {:ok, conn, cmd, address}}
   end
   def handle_call_event({:bind_session, cmd}, :starting_transaction,
         %Session{conn: conn,


### PR DESCRIPTION
This is a partial attempt to fix https://github.com/zookzook/elixir-mongodb-driver/issues/63.

The goals are:

- When an error is received, check if it's one of the not master/node recovering codes.
- If so, mark the server used for the operation unknown.

My current hang up is I don't understand how to get the address out of the connection. My impression is it isn't stored on the connection itself.

In general I find the driver difficult to work with due to lack of comments/API docs. In many cases I have no idea what type a variable is, and hence what it contains.

Also, as far as I can tell there isn't support for walking the stack up/down in iex, making debugging virtually impossible. Is elixir impractical without an ide? Do IDEs allow you to walk the stack up and down? I *think* the screenshots of jetbrains suggest this is possible.