### PR TITLE
Add proper support for tailable cursors and awaitData

### DIFF
--- a/lib/mongo.ex
+++ b/lib/mongo.ex
@@ -657,7 +657,6 @@ defmodule Mongo do
            showRecordId: opts[:show_record_id],
            tailable: opts[:tailable],
            oplogReplay: opts[:oplog_replay],
-           tailable: opts[:tailable],
            noCursorTimeout: opts[:no_cursor_timeout],
            awaitData: opts[:await_data],
            batchSize: opts[:batch_size],


### PR DESCRIPTION
This PR fixes a minor oversight in the `Mongo.Stream` module. When streaming a cursor, `next_fun` would halt streaming if a batch of documents came up empty for a live cursor, overlooking whether the cursor was marked tailable. This causes tailable cursors to halt immediately after initial exhaustion of documents.

This behavior has been fixed, including a test to ensure tailable cursors with awaitData continue to behave in the appropriate manner.

This required including the originating command used to create a `Mongo.Stream` struct, called `cmd`. This keyword list is passed on to the internal `state` record of the module's `Enumerable` implementation, so that the tailability of the cursor is known when deciding how to handle an empty batch of documents.