### PR TITLE
Fix build warnings

### DIFF
--- a/lib/mongo/grid_fs/bucket.ex
+++ b/lib/mongo/grid_fs/bucket.ex
@@ -121,17 +121,17 @@ defmodule Mongo.GridFs.Bucket do
     Mongo.find(topology_pid, files_collection_name(bucket), filter, opts)
   end
 
+
   @doc """
-  Finds one file document with the file_id as a string
+  Finds one file document by `file_id` specified either as a string or `BSON.ObjectId`.
   """
+  def find_one(bucket, file_id)
+
   @spec find_one(Bucket.t, String.t) :: BSON.document | nil
   def find_one(%Bucket{} = bucket, file_id) when is_binary(file_id) do
     find_one(bucket, ObjectId.decode!(file_id))
   end
 
-  @doc """
-  Finds one file document with the file_id as an ObjectID-struct
-  """
   @spec find_one(Bucket.t, BSON.ObjectId.t) :: BSON.document | nil
   def find_one(%Bucket{topology_pid: topology_pid, opts: opts} = bucket, %BSON.ObjectId{} = oid) do
      Mongo.find_one(topology_pid, files_collection_name(bucket), %{"_id" => oid}, opts)

--- a/lib/mongo/grid_fs/bucket.ex
+++ b/lib/mongo/grid_fs/bucket.ex
@@ -121,7 +121,6 @@ defmodule Mongo.GridFs.Bucket do
     Mongo.find(topology_pid, files_collection_name(bucket), filter, opts)
   end
 
-
   @doc """
   Finds one file document by `file_id` specified either as a string or `BSON.ObjectId`.
   """

--- a/mix.exs
+++ b/mix.exs
@@ -28,9 +28,12 @@ defmodule Mongodb.Mixfile do
   defp elixirc_paths(_),     do: ["lib"]
 
   def application() do
-    [applications: applications(Mix.env),
-     mod: {Mongo.App, []},
-     env: []]
+    [
+      applications: applications(Mix.env),
+      env: [],
+      extra_applications: [:crypto, :ssl],
+      mod: {Mongo.App, []}
+    ]
   end
 
   def applications(:test), do: [:logger, :connection, :db_connection]


### PR DESCRIPTION
Fixes these warnings:

```
warning: redefining @doc attribute previously set at line 124.

Please remove the duplicate docs. If instead you want to override a previously defined @doc, attach the @doc attribute to a function head:

    @doc """
    new docs
    """
    def find_one(...)

  lib/mongo/grid_fs/bucket.ex:132: Mongo.GridFs.Bucket.find_one/2

warning: :crypto.crypto_one_time/5 defined in application :crypto is used by the current application but the current application does not depend on :crypto. To fix this, you must do one of:

  1. If :crypto is part of Erlang/Elixir, you must include it under :extra_applications inside "def application" in your mix.exs

  2. If :crypto is a dependency, make sure it is listed under "def deps" in your mix.exs

  3. In case you don't want to add a requirement to :crypto, you may optionally skip this warning by adding [xref: [exclude: [:crypto]]] to your "def project" in mix.exs

Found at 2 locations:
  lib/mongo/password_safe.ex:56: Mongo.PasswordSafe.encrypt/2
  lib/mongo/password_safe.ex:62: Mongo.PasswordSafe.decrypt/2

warning: :crypto.exor/2 defined in application :crypto is used by the current application but the current application does not depend on :crypto. To fix this, you must do one of:

  1. If :crypto is part of Erlang/Elixir, you must include it under :extra_applications inside "def application" in your mix.exs

  2. If :crypto is a dependency, make sure it is listed under "def deps" in your mix.exs

  3. In case you don't want to add a requirement to :crypto, you may optionally skip this warning by adding [xref: [exclude: [:crypto]]] to your "def project" in mix.exs

  lib/mongo/pbkdf2.ex:54: Mongo.PBKDF2.iterate/4

warning: :crypto.hash/2 defined in application :crypto is used by the current application but the current application does not depend on :crypto. To fix this, you must do one of:

  1. If :crypto is part of Erlang/Elixir, you must include it under :extra_applications inside "def application" in your mix.exs

  2. If :crypto is a dependency, make sure it is listed under "def deps" in your mix.exs

  3. In case you don't want to add a requirement to :crypto, you may optionally skip this warning by adding [xref: [exclude: [:crypto]]] to your "def project" in mix.exs

Found at 4 locations:
  lib/mongo/auth/scram.ex:79: Mongo.Auth.SCRAM.generate_proof/3
  lib/mongo/id_server.ex:82: Mongo.IdServer.machine_id/0
  lib/mongo_db_connection/utils.ex:128: Mongo.MongoDBConnection.Utils.digest/3
  lib/mongo_db_connection/utils.ex:133: Mongo.MongoDBConnection.Utils.digest_password/3

warning: :crypto.hmac/3 defined in application :crypto is used by the current application but the current application does not depend on :crypto. To fix this, you must do one of:

  1. If :crypto is part of Erlang/Elixir, you must include it under :extra_applications inside "def application" in your mix.exs

  2. If :crypto is a dependency, make sure it is listed under "def deps" in your mix.exs

  3. In case you don't want to add a requirement to :crypto, you may optionally skip this warning by adding [xref: [exclude: [:crypto]]] to your "def project" in mix.exs

Found at 5 locations:
  lib/mongo/auth/scram.ex:78: Mongo.Auth.SCRAM.generate_proof/3
  lib/mongo/auth/scram.ex:80: Mongo.Auth.SCRAM.generate_proof/3
  lib/mongo/auth/scram.ex:86: Mongo.Auth.SCRAM.generate_signature/3
  lib/mongo/auth/scram.ex:87: Mongo.Auth.SCRAM.generate_signature/3
  lib/mongo/pbkdf2.ex:58: Mongo.PBKDF2.mac_fun/2

warning: :crypto.strong_rand_bytes/1 defined in application :crypto is used by the current application but the current application does not depend on :crypto. To fix this, you must do one of:

  1. If :crypto is part of Erlang/Elixir, you must include it under :extra_applications inside "def application" in your mix.exs

  2. If :crypto is a dependency, make sure it is listed under "def deps" in your mix.exs

  3. In case you don't want to add a requirement to :crypto, you may optionally skip this warning by adding [xref: [exclude: [:crypto]]] to your "def project" in mix.exs

Found at 4 locations:
  lib/mongo.ex:239: Mongo.uuid4/0
  lib/mongo/auth/scram.ex:94: Mongo.Auth.SCRAM.nonce/0
  lib/mongo/password_safe.ex:55: Mongo.PasswordSafe.encrypt/2
  lib/mongo/password_safe.ex:68: Mongo.PasswordSafe.generate_key/0

warning: :ssl.connect/3 defined in application :ssl is used by the current application but the current application does not depend on :ssl. To fix this, you must do one of:

  1. If :ssl is part of Erlang/Elixir, you must include it under :extra_applications inside "def application" in your mix.exs

  2. If :ssl is a dependency, make sure it is listed under "def deps" in your mix.exs

  3. In case you don't want to add a requirement to :ssl, you may optionally skip this warning by adding [xref: [exclude: [:ssl]]] to your "def project" in mix.exs

  lib/mongo/mongo_db_connection.ex:95: Mongo.MongoDBConnection.ssl/2

warning: :ssl.format_error/1 defined in application :ssl is used by the current application but the current application does not depend on :ssl. To fix this, you must do one of:

  1. If :ssl is part of Erlang/Elixir, you must include it under :extra_applications inside "def application" in your mix.exs

  2. If :ssl is a dependency, make sure it is listed under "def deps" in your mix.exs

  3. In case you don't want to add a requirement to :ssl, you may optionally skip this warning by adding [xref: [exclude: [:ssl]]] to your "def project" in mix.exs

  lib/mongo/error.ex:59: Mongo.Error.exception/1
```