### PR TITLE
Replace deprecated functions

### DIFF
--- a/lib/mongo/auth/scram.ex
+++ b/lib/mongo/auth/scram.ex
@@ -88,7 +88,7 @@ defmodule Mongo.Auth.SCRAM do
   end
 
   defp xor_keys("", "", result), do: result
-  defp xor_keys(<<fa, ra::binary>>, <<fb, rb::binary>>, result), do: xor_keys(ra, rb, <<result::binary, fa ^^^ fb>>)
+  defp xor_keys(<<fa, ra::binary>>, <<fb, rb::binary>>, result), do: xor_keys(ra, rb, <<result::binary, bxor(fa, fb)>>)
 
   defp nonce do
     :crypto.strong_rand_bytes(18) |> Base.encode64

--- a/lib/mongo/auth/scram.ex
+++ b/lib/mongo/auth/scram.ex
@@ -75,16 +75,16 @@ defmodule Mongo.Auth.SCRAM do
   end
 
   defp generate_proof(salted_password, auth_message, digest) do
-    client_key   = :crypto.hmac(digest, salted_password, "Client Key")
+    client_key   = :crypto.mac(:hmac, digest, salted_password, "Client Key")
     stored_key   = :crypto.hash(digest, client_key)
-    signature    = :crypto.hmac(digest, stored_key, auth_message)
+    signature    = :crypto.mac(:hmac, digest, stored_key, auth_message)
     client_proof = xor_keys(client_key, signature, "")
     "p=#{Base.encode64(client_proof)}"
   end
 
   defp generate_signature(salted_password, auth_message, digest) do
-    server_key = :crypto.hmac(digest, salted_password, "Server Key")
-    :crypto.hmac(digest, server_key, auth_message)
+    server_key = :crypto.mac(:hmac, digest, salted_password, "Server Key")
+    :crypto.mac(:hmac, digest, server_key, auth_message)
   end
 
   defp xor_keys("", "", result), do: result

--- a/lib/mongo/pbkdf2.ex
+++ b/lib/mongo/pbkdf2.ex
@@ -55,6 +55,6 @@ defmodule Mongo.PBKDF2 do
   end
 
   defp mac_fun(digest, secret) do
-    &:crypto.hmac(digest, secret, &1)
+    &:crypto.mac(:hmac, digest, secret, &1)
   end
 end


### PR DESCRIPTION
Since Erlang 24 deprecates `crypto:hmac/3` I guess it's time to replace it with the new api.
Added `bxor/2` as a bonus.