### PR TITLE
Add support for tls setting in connection string

### DIFF
--- a/lib/mongo/mongo_db_connection.ex
+++ b/lib/mongo/mongo_db_connection.ex
@@ -35,7 +35,7 @@ defmodule Mongo.MongoDBConnection do
       auth_mechanism: opts[:auth_mechanism] || nil,
       connection_type: Keyword.fetch!(opts, :connection_type),
       topology_pid: Keyword.fetch!(opts, :topology_pid),
-      ssl: opts[:ssl] || false
+      ssl: opts[:ssl] || opts[:tls] || false
     }
     connect(opts, state)
   end

--- a/lib/mongo/url_parser.ex
+++ b/lib/mongo/url_parser.ex
@@ -45,6 +45,7 @@ defmodule Mongo.UrlParser do
     "serverSelectionTryOnce" => ["true", "false"],
     "heartbeatFrequencyMS" => :number,
     "retryWrites" => ["true", "false"],
+    "tls" => ["true", "false"],
     "uuidRepresentation" => ["standard", "csharpLegacy", "javaLegacy", "pythonLegacy"],
     # Elixir Driver options
     "type" => ["unknown", "single", "replicaSetNoPrimary", "sharded"]

--- a/test/mongo/url_parser_test.exs
+++ b/test/mongo/url_parser_test.exs
@@ -9,7 +9,7 @@ defmodule Mongo.UrlParserTest do
       assert UrlParser.parse_url(url: "mongodb://localhost:27017") == [seeds: ["localhost:27017"]]
     end
 
-    test "cluster url" do
+    test "cluster url with ssl" do
       url =
         "mongodb://user:password@seed1.domain.com:27017,seed2.domain.com:27017,seed3.domain.com:27017/db_name?ssl=true&replicaSet=set-name&authSource=admin&maxPoolSize=5"
 
@@ -21,6 +21,26 @@ defmodule Mongo.UrlParserTest do
                auth_source: "admin",
                set_name: "set-name",
                ssl: true,
+               seeds: [
+                 "seed1.domain.com:27017",
+                 "seed2.domain.com:27017",
+                 "seed3.domain.com:27017"
+               ]
+             ]
+    end
+
+    test "cluster url with tls" do
+      url =
+        "mongodb://user:password@seed1.domain.com:27017,seed2.domain.com:27017,seed3.domain.com:27017/db_name?tls=true&replicaSet=set-name&authSource=admin&maxPoolSize=5"
+
+      assert UrlParser.parse_url(url: url) |> Keyword.drop([:pw_safe]) == [
+               password: "*****",
+               username: "user",
+               database: "db_name",
+               pool_size: 5,
+               auth_source: "admin",
+               set_name: "set-name",
+               tls: true,
                seeds: [
                  "seed1.domain.com:27017",
                  "seed2.domain.com:27017",


### PR DESCRIPTION
Since mongo version 4.2 it is possible to enable secure connections
using a new flag "tls". Added support for the flag treating it similar
to the existing "ssl" flag.