### PR TITLE
#97: added new option :checkout_timeout 

### DIFF
--- a/lib/mongo.ex
+++ b/lib/mongo.ex
@@ -10,6 +10,8 @@ defmodule Mongo do
     * `:timeout` - The maximum time that the caller is allowed the to hold the
       connection’s state (ignored when using a run/transaction connection,
       default: `15_000`)
+    * `:checkout_timeout` - The maximum time for checking out a new session and connection (default: `60_000`).
+      When the connection pool exhausted then the function call times out after :checkout_timeout.
     * `:pool` - The pooling behaviour module to use, this option is required
       unless the default `DBConnection.Connection` pool is used
     * `:pool_timeout` - The maximum time to wait for a reply when making a

--- a/lib/mongo/topology.ex
+++ b/lib/mongo/topology.ex
@@ -18,6 +18,8 @@ defmodule Mongo.Topology do
   # https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst#heartbeatfrequencyms-defaults-to-10-seconds-or-60-seconds
   @heartbeat_frequency_ms 10_000
 
+  @default_checkout_timeout 60_000
+
   @spec start_link(Keyword.t, Keyword.t) ::
           {:ok, pid} |
           {:error, reason :: atom}
@@ -51,8 +53,9 @@ defmodule Mongo.Topology do
     GenServer.call(pid, :topology)
   end
 
-  def select_server(pid, type, opts \\ []) do
-    GenServer.call(pid, {:select_server, type, opts})
+  def select_server(pid, type, opts \\ []) do#97
+    timeout = Keyword.get(opts, :checkout_timeout,  @default_checkout_timeout)
+    GenServer.call(pid, {:select_server, type, opts}, timeout)
   end
 
   def limits(pid) do
@@ -63,11 +66,9 @@ defmodule Mongo.Topology do
     GenServer.call(pid, :wire_version)
   end
 
-  @doc """
-
-  """
   def checkout_session(pid, cmd_type, type, opts \\ []) do
-    GenServer.call(pid, {:checkout_session, cmd_type, type, opts})
+    timeout = Keyword.get(opts, :checkout_timeout,  @default_checkout_timeout)
+    GenServer.call(pid, {:checkout_session, cmd_type, type, opts}, timeout)
   end
 
   def checkin_session(pid, server_session) do


### PR DESCRIPTION
to replace the default timeout of the gen server call.

When the connection pool is exhausted then the `checkout_session` call puts the caller into a queue and wait's for the next possible connection. The default timeout of the gen server call times out after 5_000 ms, which is too early. So by adding a new options :checkout_session it is possible to specify larger values. Even more, the default timeout value of the gen server call is set to 60_000.