### PR TITLE
Ensure the macro is defined before invocation

### DIFF
--- a/lib/mongo_db_connection/utils.ex
+++ b/lib/mongo_db_connection/utils.ex
@@ -1,7 +1,7 @@
 defmodule Mongo.MongoDBConnection.Utils do
   @moduledoc false
   import Kernel, except: [send: 2]
-  import Mongo.Messages
+  use Mongo.Messages
   use Bitwise
 
   # @reply_cursor_not_found   0x1


### PR DESCRIPTION
When compiling this driver as dependency in an application, the following error is returned:

```log
== Compilation error in file lib/mongo_db_connection/utils.ex ==
** (CompileError) lib/mongo_db_connection/utils.ex:66: cannot find or invoke local op_msg/1 inside match. Only macros can be invoked in a match and they must be defined before their invocation. Called as: op_msg(flags: _flags, sections: sections)
    lib/mongo_db_connection/utils.ex:66: (module)
```

I believe it's because the `op_msg` macro that was defined in the `Mongo.Messages` module and was not `required` by the `Mongo.MongoDBConnection.Utils`.

By changing from `import` to `use`, it will have the same effect because `use` is a macro and it's adding itself as an import.

> **Note:** Not sure which combination of versions requirements causes it and if someone has experienced before, but nevertheless it is the right way to import it.