### PR TITLE
Add back original query options for srv links

### DIFF
--- a/lib/mongo/url_parser.ex
+++ b/lib/mongo/url_parser.ex
@@ -137,7 +137,7 @@ defmodule Mongo.UrlParser do
 
     with url_char <- String.to_charlist(url),
          {:ok, {_, _, _, _, _, srv_record}} <-
-          :inet_res.getbyname('_mongodb._tcp.' ++ url_char, :srv),
+           :inet_res.getbyname('_mongodb._tcp.' ++ url_char, :srv),
          {:ok, host} <- get_host_srv(srv_record),
          {:ok, {_, _, _, _, _, txt_record}} <- :inet_res.getbyname(url_char, :txt),
          txt <- "#{orig_options}&#{txt_record}&ssl=true" do

--- a/lib/mongo/url_parser.ex
+++ b/lib/mongo/url_parser.ex
@@ -114,7 +114,6 @@ defmodule Mongo.UrlParser do
 
 
   defp parse_query_options(opts, %{"options" => options}) when is_binary(options) do
-    IO.puts("#{inspect(opts)} --- #{inspect(options)}")
     options
     |> String.split("&")
     |> Enum.map(fn option -> String.split(option, "=") end)

--- a/test/mongo/url_parser_test.exs
+++ b/test/mongo/url_parser_test.exs
@@ -66,6 +66,20 @@ defmodule Mongo.UrlParserTest do
                ]
     end
 
+    test "url srv with auth source" do
+      assert UrlParser.parse_url(url: "mongodb+srv://test10.test.build.10gen.cc/db?replicaSet=r1&authSource=admin") ==
+               [
+                 database: "db",
+                 ssl: true,
+                 socket_timeout_ms: 500,
+                 auth_source: "admin",
+                 set_name: "r1",
+                 seeds: [
+                   "localhost.test.build.10gen.cc:27017"
+                 ]
+               ]
+    end
+
     test "url srv with user" do
       assert UrlParser.parse_url(url: "mongodb+srv://user:password@test5.test.build.10gen.cc") |> Keyword.drop([:pw_safe]) ==
                [


### PR DESCRIPTION
I've had problems when using srv links and url query params in mongodb driver. This PR fixed the issue for me, maybe it'll help someone else too.