### PR TITLE
More graceful handling of disconnects

### DIFF
--- a/lib/mongo/mongo_db_connection.ex
+++ b/lib/mongo/mongo_db_connection.ex
@@ -44,6 +44,7 @@ defmodule Mongo.MongoDBConnection do
   def disconnect(_error, %{connection: {mod, socket}} = state) do
     notify_disconnect(state)
     mod.close(socket)
+    :ok
   end
 
   defp notify_disconnect(%{connection_type: type, topology_pid: pid, host: host}) do


### PR DESCRIPTION
Without that `:ok` it seems that `db_connection` process is dying on disconnect: https://hexdocs.pm/db_connection/DBConnection.html