### PR TITLE
Refactor transaction api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   * add telemetry support for execution
   * add new Repo module (thanks to daskycodes)
   * add missing typespecs (thanks to fdie)
+  * refactor transaction api to support nested transaction
 
 ## 0.8.4 (2022-03-09)
 * Bugfix

--- a/test/collections/simple_test.exs
+++ b/test/collections/simple_test.exs
@@ -8,7 +8,7 @@ defmodule Collections.SimpleTest do
 
   setup_all do
     assert {:ok, pid} = Mongo.TestConnection.connect()
-    Mongo.drop_database(pid)
+    Mongo.drop_database(pid, nil, w: 3)
     {:ok, [pid: pid]}
   end
 

--- a/test/mongo/change_stream_test.exs
+++ b/test/mongo/change_stream_test.exs
@@ -4,7 +4,7 @@ defmodule Mongo.ChangeStreamTest do
 
   setup_all do
     assert {:ok, top} = Mongo.TestConnection.connect()
-    Mongo.drop_database(top)
+    Mongo.drop_database(top, nil, w: 3)
     assert {:ok, %Mongo.InsertOneResult{}} = Mongo.insert_one(top, "users", %{name: "Waldo"})
     %{pid: top}
   end

--- a/test/mongo/encoder_test.exs
+++ b/test/mongo/encoder_test.exs
@@ -4,7 +4,7 @@ defmodule Mongo.EncoderTest do
 
   setup_all do
     assert {:ok, pid} = Mongo.TestConnection.connect()
-    Mongo.drop_database(pid)
+    Mongo.drop_database(pid, nil, w: 3)
     {:ok, [pid: pid]}
   end
 

--- a/test/mongo/not_writable_primary_test.exs
+++ b/test/mongo/not_writable_primary_test.exs
@@ -3,7 +3,7 @@ defmodule Mongo.NotWritablePrimaryTest do
 
   setup_all do
     assert {:ok, top} = Mongo.TestConnection.connect()
-    Mongo.drop_database(top)
+    Mongo.drop_database(top, nil, w: 3)
     %{pid: top}
   end
 

--- a/test/mongo/transaction_retries_test.exs
+++ b/test/mongo/transaction_retries_test.exs
@@ -158,7 +158,7 @@ defmodule Mongo.TransactionRetriesTest do
 
     Mongo.admin_command(top, configureFailPoint: "failCommand", mode: "off")
 
-    assert [:configureFailPoint, :abortTransaction, :insert, :configureFailPoint, :create] = get_succeeded_events(catcher)
+    assert [:configureFailPoint, :abortTransaction, :insert, :configureFailPoint, :create] = get_succeeded_events(catcher) |> Enum.reject(fn event -> event == :more_to_come end)
   end
 
   defp get_succeeded_events(catcher) do

--- a/test/support/collection_case.ex
+++ b/test/support/collection_case.ex
@@ -9,7 +9,7 @@ defmodule CollectionCase do
   setup_all do
     assert {:ok, pid} = Mongo.start_link(database: "mongodb_test", seeds: @seeds, show_sensitive_data_on_connection_error: true)
     Mongo.admin_command(pid, configureFailPoint: "failCommand", mode: "off")
-    Mongo.drop_database(pid)
+    Mongo.drop_database(pid, nil, w: 3)
     {:ok, [pid: pid]}
   end
 


### PR DESCRIPTION
The goal is to use nested transaction function calls like this:

```elixir
def test_transaction(conn) do
  Mongo.transaction(conn, fn ->
    Mongo.insert_one(:mongo, "dogs", %{name: "Tom", age: 13})
    test_insert_1(conn)
    test_insert_2(conn)
  end)
end

def test_insert_1(conn) do
  Mongo.insert_one(conn, "dogs", %{name: "Greta", age: 11})
end

def test_insert_2(conn) do
  Mongo.transaction(conn, fn ->
    Mongo.insert_one(:mongo, "dogs", %{name: "Oskar", age: 13})
    :error
  end)
end
```

All insert commands should participate the current transaction in call `test_transaction/1`.