### PR TITLE
Fix CaseClauseError when update a document without any change

### DIFF
--- a/lib/mongo/repo.ex
+++ b/lib/mongo/repo.ex
@@ -75,7 +75,7 @@ defmodule Mongo.Repo do
 
           case Mongo.update_one(@topology, collection, %{_id: id}, %{"$set" => module.dump(doc)}, []) do
             {:error, reason} -> {:error, reason}
-            {:ok, %{modified_count: 1}} -> {:ok, doc}
+            {:ok, %{modified_count: _}} -> {:ok, doc}
           end
         end
 
@@ -85,7 +85,7 @@ defmodule Mongo.Repo do
           case Mongo.update_one(@topology, collection, %{_id: id}, %{"$set" => module.dump(doc)}, upsert: true) do
             {:error, reason} -> {:error, reason}
             {:ok, %{upserted_ids: [id]}} -> {:ok, %{doc | _id: id}}
-            {:ok, %{modified_count: 1}} -> {:ok, doc}
+            {:ok, %{modified_count: _}} -> {:ok, doc}
           end
         end
 
@@ -117,7 +117,7 @@ defmodule Mongo.Repo do
 
           case update_one_result do
             %{upserted_ids: [id]} -> %{doc | _id: id}
-            %{modified_count: 1} -> doc
+            %{modified_count: _} -> doc
           end
         end
 

--- a/test/mongo/repo_test.exs
+++ b/test/mongo/repo_test.exs
@@ -348,6 +348,15 @@ defmodule Mongo.RepoTest do
         |> Map.put(:title, "updated")
         |> MyRepo.update()
     end
+
+    test "updates a document without changes" do
+      {:ok, post} =
+        Post.new()
+        |> Map.put(:title, "test")
+        |> MyRepo.insert()
+
+      {:ok, %Post{title: "test"}} = MyRepo.update(post)
+    end
   end
 
   describe "update!/1" do
@@ -361,6 +370,15 @@ defmodule Mongo.RepoTest do
         post
         |> Map.put(:title, "updated")
         |> MyRepo.update!()
+    end
+
+    test "updates a document without changes" do
+      {:ok, post} =
+        Post.new()
+        |> Map.put(:title, "test")
+        |> MyRepo.insert()
+
+      %Post{title: "test"} = MyRepo.update!(post)
     end
   end
 
@@ -388,6 +406,18 @@ defmodule Mongo.RepoTest do
       assert Map.get(post, :_id) == Map.get(updated, :_id)
       assert updated.title == "updated"
     end
+
+    test "updates a document without changes if it does already exist" do
+      {:ok, post} =
+        Post.new()
+        |> Map.put(:title, "test")
+        |> MyRepo.insert_or_update()
+
+      {:ok, updated} = MyRepo.insert_or_update(post)
+
+      assert Map.get(post, :_id) == Map.get(updated, :_id)
+      assert updated.title == "test"
+    end
   end
 
   describe "insert_or_update!/1" do
@@ -413,6 +443,18 @@ defmodule Mongo.RepoTest do
 
       assert Map.get(post, :_id) == Map.get(updated, :_id)
       assert updated.title == "updated"
+    end
+
+    test "updates a document without changes if it does already exist" do
+      post =
+        Post.new()
+        |> Map.put(:title, "test")
+        |> MyRepo.insert_or_update!()
+
+      updated = MyRepo.insert_or_update!(post)
+
+      assert Map.get(post, :_id) == Map.get(updated, :_id)
+      assert updated.title == "test"
     end
   end
 


### PR DESCRIPTION

When using the functions `Repo.update/1`, `Repo.insert_or_update/1` and `Repo.insert_or_update!/1` to update a document without changing any attributes an exception is raised.

```elixir
post = MyRepo.get_by(Post, %{})
MyRepo.update(post)

** (CaseClauseError) no case clause matching: {:ok, %Mongo.UpdateResult{acknowledged: true, matched_count: 1, modified_count: 0, upserted_ids: []}}
    (mongo_test 0.0.1) lib/repo.ex:2: MyRepo.update/1
```

Not sure if this behavior was intentional, since the error doesn't happen in `Repo.update!/1`

I initially thought that validating if the modified_count was less than or equal to 1, but I don't believe it's something that makes any difference.

What do you think about this approach?