### PR TITLE
Use :NaN for Decimal encoding

### DIFF
--- a/test/bson/decimal128_test.exs
+++ b/test/bson/decimal128_test.exs
@@ -18,7 +18,7 @@ defmodule BSON.Decimal128Test do
 
   @tag :mongo_3_4
   test "BSON.Decimal128.decode/1" do
-    assert_decimal(@nan_binaries, %Decimal{coef: :qNaN})
+    assert_decimal(@nan_binaries, %Decimal{coef: :NaN})
     assert_decimal(@inf_binaries, %Decimal{coef: :inf})
     assert_decimal(@neg_inf_binaries, %Decimal{sign: -1, coef: :inf})
     assert_decimal(@binaries_0, %Decimal{coef: 0})
@@ -45,8 +45,7 @@ defmodule BSON.Decimal128Test do
 
   @tag :mongo_3_4
   test "BSON.Decimal128.encode/1" do
-    assert_decimal(%Decimal{coef: :qNaN})
-    assert_decimal(%Decimal{coef: :sNaN})
+    assert_decimal(%Decimal{coef: :NaN})
     assert_decimal(%Decimal{sign: -1, coef: :inf})
     assert_decimal(%Decimal{coef: :inf})
     assert_decimal(%Decimal{coef: 0, exp: -611})

--- a/test/mongo_test.exs
+++ b/test/mongo_test.exs
@@ -537,8 +537,7 @@ defmodule Mongo.Test do
 
     values =
       [
-        %Decimal{coef: :qNaN},
-        %Decimal{coef: :sNaN},
+        %Decimal{coef: :NaN},
         %Decimal{sign: -1, coef: :inf},
         %Decimal{coef: :inf},
         %Decimal{coef: 0, exp: -611},


### PR DESCRIPTION
The [Decimal module documents](https://hexdocs.pm/decimal/Decimal.html#t:coefficient/0) the use of `:inf` and `:NaN` but not `:qNaN` or `:sNaN`. It refers to `:NaN` as being a quiet NaN. Signalling NaNs are generally expected to trigger an error at the hardware level and then handled by being converted to a quiet NaN if execution should continue.

This PR proposes not storing signalling NaNs in the database and decoding NaN into `:NaN` instead of `:qNaN`. I don't know if that's problematic from a compatibility stance, but it's what the Decimal module expects:

```elixir
iex> Decimal.nan?(%Decimal{coef: :NaN})
true
iex> Decimal.nan?(%Decimal{coef: :qNaN})
false
iex> Decimal.parse("NaN")
{#Decimal<NaN>, ""}
iex> Decimal.parse("qNaN")
:error
```

Any feedback or comments about how NaN is expected to be used are appreciated too.