### PR TITLE
Adds a default timeout of 5 min for github actions

### DIFF
--- a/.github/workflows/mongodb_driver.yml
+++ b/.github/workflows/mongodb_driver.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   test:
     name: Compile and Test
+    timeout-minutes: 5
 
     strategy:
       matrix:


### PR DESCRIPTION
I tried to make a test with mongodb 4.0 on the PR [!145](https://github.com/zookzook/elixir-mongodb-driver/pull/145) but every test was timing out and I couldn't cancel the workflow job.

To prevent something like this from happening again, I propose to add this execution timeout.

Based on he previous duration I think 5 minutes is enough to run each normal job. 

Github docs -> https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idtimeout-minutes