### PR TITLE
Add :name option to attribute, embeds_one and embeds_many

### DIFF
--- a/lib/mongo/collection.ex
+++ b/lib/mongo/collection.ex
@@ -673,8 +673,10 @@ defmodule Mongo.Collection do
         _ -> raise ArgumentError, "name must be an atom or a binary"
       end
 
-    if name_exists?(mod, name),
-      do: raise(ArgumentError, "key #{inspect(name)} name already exist"),
+    {src_name, _} = opts[:name]
+
+    if name_exists?(mod, src_name),
+      do: raise(ArgumentError, "attribute #{inspect(name)} has duplicate name option key\n\n    [name: #{inspect(src_name)}] already exist\n"),
       else: opts
   end
 
@@ -685,13 +687,13 @@ defmodule Mongo.Collection do
   defp name_exists?(mod, :attributes, name) do
     mod
     |> Module.get_attribute(:attributes)
-    |> Enum.any?(fn {_name, opts} -> opts[:name] == name end)
+    |> Enum.any?(fn {_name, opts} -> elem(opts[:name], 0) == name end)
   end
 
   defp name_exists?(mod, embeds, name) do
     mod
     |> Module.get_attribute(embeds)
-    |> Enum.any?(fn {_name, _mod, opts} -> opts[:name] == name end)
+    |> Enum.any?(fn {_name, _mod, opts} -> elem(opts[:name], 0) == name end)
   end
 
   @doc """

--- a/lib/mongo/collection.ex
+++ b/lib/mongo/collection.ex
@@ -618,18 +618,18 @@ defmodule Mongo.Collection do
           Enum.map(xs, fn struct -> dump(struct) end)
         end
 
-        def dump(%__MODULE__{} = struct) do
-          struct =
+        def dump(%{} = map) do
+          map =
             unquote(embed_ones)
-            |> Enum.map(fn {name, {_src_name, mod}} -> {name, mod.dump(Map.get(struct, name))} end)
-            |> Enum.reduce(struct, fn {name, doc}, acc -> Map.put(acc, name, doc) end)
+            |> Enum.map(fn {name, {_src_name, mod}} -> {name, mod.dump(Map.get(map, name))} end)
+            |> Enum.reduce(map, fn {name, doc}, acc -> Map.put(acc, name, doc) end)
 
-          struct =
+          map =
             unquote(embed_manys)
-            |> Enum.map(fn {name, {_src_name, mod}} -> {name, mod.dump(Map.get(struct, name))} end)
-            |> Enum.reduce(struct, fn {name, doc}, acc -> Map.put(acc, name, doc) end)
+            |> Enum.map(fn {name, {_src_name, mod}} -> {name, mod.dump(Map.get(map, name))} end)
+            |> Enum.reduce(map, fn {name, doc}, acc -> Map.put(acc, name, doc) end)
 
-          struct
+          map
           |> Map.drop(unquote(@derived))
           |> @before_dump_fun.()
           |> Collection.dump()

--- a/test/collections/simple_test.exs
+++ b/test/collections/simple_test.exs
@@ -76,6 +76,8 @@ defmodule Collections.SimpleTest do
     alias Collections.SimpleTest.Card
     alias Collections.SimpleTest.Label
 
+    assert %{l: %{c: "red"}, title: nil} = Card.dump(%{label: %{color: "red"}, title: nil})
+
     new_card = Card.new()
     map_card = Card.dump(new_card)
 
@@ -83,7 +85,7 @@ defmodule Collections.SimpleTest do
 
     struct_card = Card.load(map_card, true)
 
-    assert %Card{created: _, intro: "new intro", label: %Label{color: :red, name: "warning"}} = struct_card
+    assert %Card{intro: "new intro", label: %Label{color: :red, name: "warning"}} = struct_card
   end
 
   test "save and find", c do

--- a/test/collections/simple_test.exs
+++ b/test/collections/simple_test.exs
@@ -39,7 +39,7 @@ defmodule Collections.SimpleTest do
       attribute :title, String.t(), default: "new title"
       attribute :intro, String.t(), default: "new intro", name: "i"
       embeds_one(:label, Label, default: &Label.new/0, name: :l)
-      timestamps(inserted_at: :created, updated_at: :modified, default: &Card.ts/0)
+      timestamps(inserted_at: {:created, :c_at}, updated_at: :modified, default: &Card.ts/0)
     end
 
     def insert_one(%Card{} = card, top) do
@@ -69,7 +69,7 @@ defmodule Collections.SimpleTest do
     map_card = Card.dump(new_card)
 
     ts = Map.get(new_card, :created)
-    assert %{created: ^ts, modified: ^ts} = map_card
+    assert %{c_at: ^ts, modified: ^ts} = map_card
   end
 
   test "load and dump", _c do
@@ -79,11 +79,11 @@ defmodule Collections.SimpleTest do
     new_card = Card.new()
     map_card = Card.dump(new_card)
 
-    assert %{title: "new title", i: "new intro", l: %{c: :red, name: "warning"}} = map_card
+    assert %{c_at: _, title: "new title", i: "new intro", l: %{c: :red, name: "warning"}} = map_card
 
     struct_card = Card.load(map_card, true)
 
-    assert %Card{intro: "new intro", label: %Label{color: :red, name: "warning"}} = struct_card
+    assert %Card{created: _, intro: "new intro", label: %Label{color: :red, name: "warning"}} = struct_card
   end
 
   test "save and find", c do


### PR DESCRIPTION
Save custom attribute names in DB

**Struct**

```elixir
%Collections.SimpleTest.Card{
  label: %Collections.SimpleTest.Label{color: :red, name: "warning"}, 
  _id: #BSON.ObjectId<634b114298234fa6c2cb7e9d>,
  created: ~U[2022-10-15 20:00:02.686000Z], 
  intro: "new intro",
  modified: ~U[2022-10-15 20:00:02.686000Z],
  title: "new title"
}
```

**Map**

```elixir
%{
  l: %{name: "warning", c: :red},
  title: "new title",
  _id: #BSON.ObjectId<634b114298234fa6c2cb7e9d>,
  created: ~U[2022-10-15 20:00:02.686000Z],
  i: "new intro",
  modified: ~U[2022-10-15 20:00:02.686000Z]
}
```

**MongodDB Compass** preview

<img width="1117" alt="Снимок экрана 2022-10-16 в 02 04 26" src="https://user-images.githubusercontent.com/4083992/196005648-52ebab73-c7d1-4e15-b5e0-a45b7d9cdc0f.png">
