### PR TITLE
Fix mongo.drop task and add error handling

### DIFF
--- a/lib/mongo/migration.ex
+++ b/lib/mongo/migration.ex
@@ -78,6 +78,11 @@ defmodule Mongo.Migration do
       _other ->
         :noop
     end
+  rescue
+    e ->
+      IO.puts("🚨 Error when migrating #{mod}:")
+      IO.puts(Exception.format(:error, e, __STACKTRACE__))
+      reraise e, __STACKTRACE__
   end
 
   defp run_down(version, mod) do
@@ -85,7 +90,7 @@ defmodule Mongo.Migration do
     collection = get_config()[:collection]
 
     case Mongo.find_one(topology, collection, %{version: version}) do
-      %{version: _version} ->
+      %{"version" => _version} ->
         mod.down()
         Mongo.delete_one(topology, collection, %{version: version})
         IO.puts("💥 Successfully dropped #{mod}")
@@ -93,6 +98,11 @@ defmodule Mongo.Migration do
       _other ->
         :noop
     end
+  rescue
+    e ->
+      IO.puts("🚨 Error when dropping #{mod}:")
+      IO.puts(Exception.format(:error, e, __STACKTRACE__))
+      reraise e, __STACKTRACE__
   end
 
   def get_config() do


### PR DESCRIPTION
_**First: sorry if my changes don't follow best practices or are wrong in some way. I discovered these issues while building my first ever elixir application, so I'm brand new to the language 😄**_

This PR contains two changes to the new migration feature. I noticed that one of my migrations was failing to run but I got no errors and the rest of the migrations continued as if nothing was wrong.

I expected there to be error output when my migration failed, and I expected a failed migration to halt further migrations. This is because all migrations should run in order as there could be a dependency on a previous migration running successfully.

The changes I made to support these expectations:

1. [Fix] The pattern match of the `Mongo.find_one` on `run_down` was expecting an atom key when it actually returns a string key. This resulted in the `:noop` for all migrations.

2. [Fix/Enhancement] Added error handling to the `run_up` and `run_down` that rescues any errors, outputs the error and stack trace and finally reraises the error so the parent function can unlock the migration document.

This allows migration authors to do pattern matching against the return value of any migration commands like index addition. Here is an exact buggy migration I had, and the new output:

```elixir
defmodule Mongo.Migrations.AddUserTokensIndexes do
  def up() do
    indexes = [
      [key: [type: 1, hashed_token: 1, expires_at: 1], name: "type_1_hashed_token_1_expires_at_1"],
      [key: [user_id: 1, type: 1], name: "user_id_1_type_1"],
      
      # Note that expire_after_seconds should actually be expireAfterSeconds
      [key: [expires_at: 1], name: "expires_at_1", expire_after_seconds: 0]
    ]

    # Note that I pattern match the result against `:ok` in order to raise on error
    :ok = Mongo.create_indexes(:mongo, "user_tokens", indexes)
  end

  def down() do
    :ok = Mongo.drop_index(:mongo, "user_tokens", "type_1_hashed_token_1_expires_at_1")
    :ok = Mongo.drop_index(:mongo, "user_tokens", "user_id_1_type_1")
    :ok = Mongo.drop_index(:mongo, "user_tokens", "expires_at_1")
  end
end
```

The resulting output when this errors out:

```
[info] CMD find "migrations" [filter: [version: 20221112034046], limit: 1, batchSize: 1] db=2.1ms
[info] CMD createIndexes "user_tokens" [
  indexes: [
    [
      key: [type: 1, hashed_token: 1, expires_at: 1],
      name: "type_1_hashed_token_1_expires_at_1"
    ],
    [key: [user_id: 1, type: 1], name: "user_id_1_type_1"],
    [key: [expires_at: 1], name: "expires_at_1", expire_after_seconds: 0]
  ]
] db=2.5ms
🚨 Error when migrating Elixir.Mongo.Migrations.AddUserTokensIndexes:
** (MatchError) no match of right hand side value: {:error, %Mongo.Error{message: "Error in specification { key: { expires_at: 1 }, name: \"expires_at_1\", expire_after_seconds: 0 } :: caused by :: The field 'expire_after_seconds' is not valid for an index specification. Specification: { key: { expires_at: 1 }, name: \"expires_at_1\", expire_after_seconds: 0 }", code: 197, host: nil, fail_command: false, error_labels: [], resumable: false, retryable_reads: false, retryable_writes: false, not_writable_primary_or_recovering: false}}
    _build/dev/lib/sevstack/priv/mongo/migrations/20221112034046_add_user_tokens_indexes.exs:8: Mongo.Migrations.AddUserTokensIndexes.up/0
    (mongodb_driver 0.9.2) lib/mongo/migration.ex:74: Mongo.Migration.run_up/2
    (elixir 1.14.1) lib/enum.ex:975: Enum."-each/2-lists^foreach/1-0-"/2
    (mongodb_driver 0.9.2) lib/mongo/migration.ex:9: Mongo.Migration.migrate/0
    (mix 1.14.1) lib/mix/task.ex:421: anonymous fn/3 in Mix.Task.run_task/4
    (mix 1.14.1) lib/mix/cli.ex:84: Mix.CLI.run_task/2
    (elixir 1.14.1) src/elixir_compiler.erl:65: :elixir_compiler.dispatch/4
    (elixir 1.14.1) src/elixir_compiler.erl:50: :elixir_compiler.compile/3
    (elixir 1.14.1) src/elixir_lexical.erl:15: :elixir_lexical.run/3
    (elixir 1.14.1) src/elixir_compiler.erl:17: :elixir_compiler.quoted/3
    (elixir 1.14.1) lib/module/parallel_checker.ex:107: Module.ParallelChecker.verify/1
    (elixir 1.14.1) lib/code.ex:1245: Code.require_file/2
    (elixir 1.14.1) lib/kernel/cli.ex:574: Kernel.CLI.wrapper/1
    (elixir 1.14.1) lib/enum.ex:1658: Enum."-map/2-lists^map/1-0-"/2
    (elixir 1.14.1) lib/kernel/cli.ex:83: Kernel.CLI.process_commands/1
    (elixir 1.14.1) lib/kernel/cli.ex:37: anonymous fn/2 in Kernel.CLI.main/1
    (elixir 1.14.1) lib/kernel/cli.ex:131: anonymous fn/3 in Kernel.CLI.exec_fun/2

[info] CMD update "migrations" [
  updates: [
    %{multi: false, q: %{_id: "lock", used: true}, u: %{"$set": %{used: false}}}
  ]
] db=3.1ms
🔓 migrations unlocked
```