### PR TITLE
Sort migration files before execution

### DIFF
--- a/lib/mongo/migration.ex
+++ b/lib/mongo/migration.ex
@@ -118,7 +118,7 @@ defmodule Mongo.Migration do
 
   defp migration_files!() do
     case File.ls(migration_file_path()) do
-      {:ok, files} -> files
+      {:ok, files} -> Enum.sort(files)
       {:error, _} -> raise "Could not find migrations file path"
     end
   end


### PR DESCRIPTION
I noticed that one of my migrations was failing, but future migrations were still being run. It turns out that they were being run out of order. 

It looks like the `File.ls` uses erlang's `:file.dir_list` which does not return files in sorted order:

> The names are not sorted.

_https://www.erlang.org/doc/man/file.html#list_dir-1_

I just pass the returned list of files through `Enum.sort`