### PR TITLE
export locals_without_parens in formatter

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,17 +1,21 @@
 # Used by "mix format"
+locals_without_parens = [
+  # MongoDB
+  after_load: :*,
+  before_dump: :*,
+  attribute: :*,
+  collection: :*,
+  embeds_one: :*,
+  embeds_many: :*,
+  # Test
+  ## Assertions
+  assert_receive_event: :*,
+  refute_receive_event: :*
+]
+
 [
   inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"],
   line_length: 250,
-  locals_without_parens: [
-    # MongoDB
-    after_load: :*,
-    before_dump: :*,
-    attribute: :*,
-    collection: :*,
-    embeds_many: :*,
-    # Test
-    ## Assertions
-    assert_receive_event: :*,
-    refute_receive_event: :*
-  ]
+  locals_without_parens: locals_without_parens,
+  export: [locals_without_parens: locals_without_parens]
 ]

--- a/test/collections/simple_test.exs
+++ b/test/collections/simple_test.exs
@@ -66,7 +66,7 @@ defmodule Collections.SimpleTest do
     collection "cards" do
       attribute :title, String.t(), default: "new title"
       attribute :intro, String.t(), default: "new intro", name: "i"
-      embeds_one(:label, Label, default: &Label.new/0, name: :l)
+      embeds_one :label, Label, default: &Label.new/0, name: :l
       timestamps(inserted_at: {:created, :c_at}, updated_at: :modified, default: &Card.ts/0)
     end
 


### PR DESCRIPTION
fixes https://github.com/zookzook/elixir-mongodb-driver/issues/159

This PR also adds `embeds_one: :*` to the locals_without_parens list and formats the one usage of it.