### PR TITLE
Adds options argument to some functions

### DIFF
--- a/lib/mongo/repo.ex
+++ b/lib/mongo/repo.ex
@@ -84,7 +84,7 @@ defmodule Mongo.Repo do
         def insert_or_update(%{__struct__: module, _id: id} = doc, opts \\ []) do
           collection = module.__collection__(:collection)
           doc = module.timestamps(doc)
-          Keyword.put(opts, :upsert, true)
+          opts = Keyword.put(opts, :upsert, true)
 
           case Mongo.update_one(@topology, collection, %{_id: id}, %{"$set" => module.dump(doc)}, opts) do
             {:error, reason} -> {:error, reason}


### PR DESCRIPTION
There were some functions in the Repo module that did not accepts options. Some of those options (such as :database) are important to be able to pass through to the underlying Mongo functions.

I'm not sure if this is the right way to implement this. I'm fairly new to behaviors so I'm not sure if changing the arity of those functions is a breaking change. Any suggestions would be welcome. It's a small thing, so I'm also happy to start over if this needs to be done completely differently.