### PR TITLE
Fix some typespecs

### DIFF
--- a/lib/mongo.ex
+++ b/lib/mongo.ex
@@ -70,8 +70,8 @@ defmodule Mongo do
 
   @type conn :: DbConnection.Conn
   @type collection :: String.t()
-  @opaque cursor :: Mongo.Cursor.t()
-  @type result(t) :: :ok | {:ok, t} | {:error, Mongo.Error.t()}
+  @type cursor :: Mongo.Cursor.t()
+  @type result(t) :: :ok | {:ok, t} | {:error, Mongo.Error.t()} | {:error, Mongo.WriteError.t()}
   @type result!(t) :: t
   @type initial_type :: :unknown | :single | :replica_set_no_primary | :sharded
 

--- a/lib/mongo/error.ex
+++ b/lib/mongo/error.ex
@@ -217,6 +217,12 @@ end
 defmodule Mongo.WriteError do
   defexception [:n, :ok, :write_errors]
 
+  @type t :: %__MODULE__{
+          n: number,
+          ok: number,
+          write_errors: [map]
+        }
+
   def message(e) do
     "n: #{e.n}, ok: #{e.ok}, write_errors: #{inspect(e.write_errors)}"
   end


### PR DESCRIPTION
Fixes a couple of typespecs which can make dialyzer fail in projects using this library.

Specifically, the `@type result(t)` can also be `{:error, Mongo.WriteError.t()}` as returned, for example, when inserting a document with an already existing `_id`:

```
iex(4)> {:ok, pid} = Mongo.start_link([hostname: "192.168.56.105", database: "test"])
{:ok, #PID<0.290.0>}
iex(5)> Mongo.insert_one(pid, "prova", %{_id: "foo"})                                
{:ok, %Mongo.InsertOneResult{acknowledged: true, inserted_id: "foo"}}
iex(6)> Mongo.insert_one(pid, "prova", %{_id: "foo"})
{:error,
 %Mongo.WriteError{
   n: 0,
   ok: 1.0,
   write_errors: [
     %{
       "code" => 11000,
       "errmsg" => "E11000 duplicate key error collection: test.prova index: _id_ dup key: { _id: \"foo\" }",
       "index" => 0,
       "keyPattern" => %{"_id" => 1},
       "keyValue" => %{"_id" => "foo"}
     }
   ]
 }}
```

Regarding the opaqueness of the `cursor` type, I don't really see a reason for it to be opaque, and being opaque prevents the possibility to pattern match on it to check for errors (like in the following example) and have dialyzer succeed:
```
case Mongo.aggregate(my_mongo_pid, coll, pipeline) do
   %Mongo.Stream{} = cursor ->
     {:ok, Enum.to_list(cursor)}

   {:error, %Mongo.Error{} = err} ->
     {:error, {:execution, err.code, err.message}}
end
```