### PR TITLE
Forwards the :database option to the migration collection calls

### DIFF
--- a/lib/mongo/migration.ex
+++ b/lib/mongo/migration.ex
@@ -183,6 +183,6 @@ defmodule Mongo.Migration do
   end
 
   defp get_database_opts(opts) do
-    if (opts[:database]), do: [database: opts[:database]], else: []
+    if opts[:database], do: [database: opts[:database]], else: []
   end
 end

--- a/lib/mongo/migration.ex
+++ b/lib/mongo/migration.ex
@@ -34,11 +34,12 @@ defmodule Mongo.Migration do
   def lock(opts \\ []) do
     topology = get_config(opts)[:topology]
     collection = get_config(opts)[:collection]
+    collection_opts = get_database_opts(opts) |> Keyword.put(:upsert, true)
 
     query = %{_id: "lock", used: false}
     set = %{"$set": %{used: true}}
 
-    case Mongo.update_one(topology, collection, query, set, upsert: true) do
+    case Mongo.update_one(topology, collection, query, set, collection_opts) do
       {:ok, %{modified_count: 1}} ->
         IO.puts("🔒 #{collection} locked")
         :locked
@@ -57,8 +58,9 @@ defmodule Mongo.Migration do
     collection = get_config(opts)[:collection]
     query = %{_id: "lock", used: true}
     set = %{"$set": %{used: false}}
+    collection_opts = get_database_opts(opts)
 
-    case Mongo.update_one(topology, collection, query, set) do
+    case Mongo.update_one(topology, collection, query, set, collection_opts) do
       {:ok, %{modified_count: 1}} ->
         IO.puts("🔓 #{collection} unlocked")
         :unlocked
@@ -71,8 +73,9 @@ defmodule Mongo.Migration do
   defp run_up(version, mod, opts) do
     topology = get_config(opts)[:topology]
     collection = get_config(opts)[:collection]
+    collection_opts = get_database_opts(opts)
 
-    case Mongo.find_one(topology, collection, %{version: version}) do
+    case Mongo.find_one(topology, collection, %{version: version}, collection_opts) do
       nil ->
         ## check, if the function supports options
 
@@ -87,7 +90,7 @@ defmodule Mongo.Migration do
             raise "The module does not export the up function!"
         end
 
-        Mongo.insert_one(topology, collection, %{version: version})
+        Mongo.insert_one(topology, collection, %{version: version}, collection_opts)
         IO.puts("⚡️ Successfully migrated #{mod}")
 
       _other ->
@@ -103,8 +106,9 @@ defmodule Mongo.Migration do
   defp run_down(version, mod, opts) do
     topology = get_config(opts)[:topology]
     collection = get_config(opts)[:collection]
+    collection_opts = get_database_opts(opts)
 
-    case Mongo.find_one(topology, collection, %{version: version}) do
+    case Mongo.find_one(topology, collection, %{version: version}, collection_opts) do
       %{"version" => _version} ->
         ## check, if the function supports options
         cond do
@@ -118,7 +122,7 @@ defmodule Mongo.Migration do
             raise "The module does not export the down function!"
         end
 
-        Mongo.delete_one(topology, collection, %{version: version})
+        Mongo.delete_one(topology, collection, %{version: version}, collection_opts)
         IO.puts("💥 Successfully dropped #{mod}")
 
       _other ->
@@ -176,5 +180,9 @@ defmodule Mongo.Migration do
 
       {mod, version}
     end)
+  end
+
+  defp get_database_opts(opts) do
+    if (opts[:database]), do: [database: opts[:database]], else: []
   end
 end

--- a/test/mongo/migration_test.exs
+++ b/test/mongo/migration_test.exs
@@ -12,4 +12,18 @@ defmodule Mongo.MigrationTest do
     assert :unlocked == Migration.unlock()
     assert {:error, :not_locked} == Migration.unlock()
   end
+
+  test "test lock and unlock with database options", %{pid: top} do
+    Mongo.drop_collection(top, "migrations", database: "one")
+    Mongo.drop_collection(top, "migrations", database: "two")
+    Patch.patch(Mongo.Migration, :get_config, fn _ -> [topology: top, collection: "migrations", path: "migrations", otp_app: :mongodb_driver] end)
+    assert :locked == Migration.lock(database: "one")
+    assert :locked == Migration.lock(database: "two")
+    assert {:error, :already_locked} == Migration.lock(database: "one")
+    assert {:error, :already_locked} == Migration.lock(database: "two")
+    assert :unlocked == Migration.unlock(database: "one")
+    assert :unlocked == Migration.unlock(database: "two")
+    assert {:error, :not_locked} == Migration.unlock(database: "one")
+    assert {:error, :not_locked} == Migration.unlock(database: "two")
+  end
 end


### PR DESCRIPTION
This is a way we can support dynamic multitenancy. If you pass in the :database option into the `migrate/1` function, it will forward it onto each migrations `up` function, but we also need it to use the database option for each of the calls to the migration collection, so that each tenant's migration states are kept separate.

Perhaps there's a better more explicit way of doing this. Super open to other suggestions :)