### PR TITLE
implements String.Chars for BSON.ObjectId

### DIFF
--- a/lib/bson/types.ex
+++ b/lib/bson/types.ex
@@ -138,6 +138,10 @@ defmodule BSON.ObjectId do
       "#BSON.ObjectId<#{encoded}>"
     end
   end
+
+  defimpl String.Chars do
+    def to_string(id), do: BSON.ObjectId.encode!(id)
+  end
 end
 
 defmodule BSON.Regex do

--- a/test/bson/types_test.exs
+++ b/test/bson/types_test.exs
@@ -42,6 +42,10 @@ defmodule BSON.TypesTest do
     assert BSON.ObjectId.decode("") == :error
   end
 
+  test "to_string BSON.ObjectId" do
+    assert to_string(@objectid) == @string
+  end
+
   test "inspect BSON.Regex" do
     value = %BSON.Regex{pattern: "abc"}
     assert inspect(value) == "#BSON.Regex<\"abc\", \"\">"


### PR DESCRIPTION
I'm not sure if this is desired, but we've found this to be incredibly helpful, especially when we're translating object ids to JSON, or logging them out in a string.