### PR TITLE
feat: Find one and update array filters

### DIFF
--- a/lib/mongo.ex
+++ b/lib/mongo.ex
@@ -491,7 +491,8 @@ defmodule Mongo do
         writeConcern: write_concern(opts),
         maxTimeMS: opts[:max_time],
         collation: opts[:collation],
-        comment: opts[:comment]
+        comment: opts[:comment],
+        arrayFilters: opts[:array_filters]
       ]
       |> filter_nils()
 

--- a/test/mongo_test.exs
+++ b/test/mongo_test.exs
@@ -248,6 +248,11 @@ defmodule Mongo.Test do
     assert {:ok, value} = Mongo.find_one_and_update(c.pid, coll, %{"foo" => 43}, %{"$set" => %{baz: 1}}, upsert: true, return_document: :after)
     assert %{"foo" => 43, "baz" => 1} = value, "Should upsert"
 
+    # array_filters
+    assert {:ok, _} = Mongo.insert_one(c.pid, coll, %{foo: 44, things: [%{id: "123", name: "test"}, %{id: "456", name: "not test"}]})
+    assert {:ok, value} = Mongo.find_one_and_update(c.pid, coll, %{"foo" => 44}, %{"$set" => %{"things.$[sub].name" => "new"}}, array_filters: [%{"sub.id" => "123"}], return_document: :after)
+    assert %{"foo" => 44, "things" => [%{"id" => "123", "name" => "new"}, %{"id" => "456", "name" => "not test"}]} = value, "Should leverage array filters"
+
     # don't find return {:ok, nil}
     assert {:ok, nil} == Mongo.find_one_and_update(c.pid, coll, %{"number" => 666}, %{"$set" => %{title: "the number of the beast"}})
 


### PR DESCRIPTION
I noticed that arrayFilters was supported in the `update_one` and `update_many` functions, but not in the `find_one_and_update`.