### PR TITLE
FIX-216: Allow passing optional _id while uploading to gridfs files

### DIFF
--- a/lib/mongo/grid_fs/upload.ex
+++ b/lib/mongo/grid_fs/upload.ex
@@ -7,12 +7,12 @@ defmodule Mongo.GridFs.Upload do
 
   @doc """
   Opens a stream that the application can write the contents of the file to.
-  The driver generates the file id.
+  The driver generates the file id if not provided.
 
   User data for the 'metadata' field of the files collection document.
   """
-  @spec open_upload_stream(Mongo.GridFs.Bucket.t(), String.t(), BSON.document() | nil) :: UploadStream.t()
-  def open_upload_stream(bucket, filename, meta \\ nil) do
-    UploadStream.new(bucket, filename, meta)
+  @spec open_upload_stream(Mongo.GridFs.Bucket.t(), String.t(), BSON.document() | nil, UploadStream.file_id() | nil) :: UploadStream.t()
+  def open_upload_stream(bucket, filename, meta \\ nil, file_id \\ nil) do
+    UploadStream.new(bucket, filename, meta, file_id)
   end
 end

--- a/lib/mongo/grid_fs/upload_stream.ex
+++ b/lib/mongo/grid_fs/upload_stream.ex
@@ -20,9 +20,10 @@ defmodule Mongo.GridFs.UploadStream do
   alias Mongo.GridFs.Bucket
   alias Mongo.GridFs.UploadStream
 
+  @type file_id :: BSON.ObjectId.t() | binary()
   @type t :: %__MODULE__{
           bucket: Bucket.t(),
-          id: BSON.ObjectId.t(),
+          id: file_id(),
           filename: String.t(),
           metadata: {BSON.document() | nil}
         }
@@ -31,9 +32,9 @@ defmodule Mongo.GridFs.UploadStream do
   @doc """
   Creates a new upload stream to insert a file into the grid-fs.
   """
-  @spec new(Bucket.t(), String.t(), BSON.document() | nil) :: UploadStream.t()
-  def new(bucket, filename, metadata \\ nil) do
-    %UploadStream{bucket: bucket, filename: filename, id: Mongo.object_id(), metadata: metadata}
+  @spec new(Bucket.t(), String.t(), BSON.document() | nil, file_id() | nil) :: UploadStream.t()
+  def new(bucket, filename, metadata \\ nil, file_id \\ nil) do
+    %UploadStream{bucket: bucket, filename: filename, id: file_id || Mongo.object_id(), metadata: metadata}
   end
 
   defimpl Collectable, for: UploadStream do

--- a/test/mongo/grid_fs/upload_test.exs
+++ b/test/mongo/grid_fs/upload_test.exs
@@ -88,6 +88,22 @@ defmodule Mongo.GridFs.UploadTest do
     assert x == chksum
   end
 
+  test "upload a text file with custom id, check download, length, meta-data and checksum", c do
+    src_filename = "./test/data/test.txt"
+    bucket = Bucket.new(c.pid, j: true, w: :majority)
+    chksum = calc_checksum(src_filename)
+    file_id = Mongo.object_id()
+
+    upload_stream = Upload.open_upload_stream(bucket, "my-example-file.txt", %{tag: "checked", chk_sum: chksum}, file_id)
+
+    File.stream!(src_filename, [], 512) |> Stream.into(upload_stream) |> Stream.run()
+
+    assert file_id == upload_stream.id
+
+    %{"metadata" => %{"tag" => "checked", "chk_sum" => x}} = Mongo.find_one(c.pid, Bucket.files_collection_name(bucket), %{_id: file_id})
+    assert x == chksum
+  end
+
   @tag :mongo_4_2
   @tag :rs_required
   test "upload a text file, check download, length, meta-data and checksum transaction", c do


### PR DESCRIPTION
For: [216 - In GridFs, allow assigning a custom _id to documents in files collection](https://github.com/zookzook/elixir-mongodb-driver/issues/216)

Allowing custom ids means the _id could be a binary, which Mongo supports.