### PR TITLE
Implement Mongo.Repo.child_spec/1

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,12 +454,12 @@ config :my_app, MyApp.Repo,
   queue_target: 5_000
 ```
 
-Finally, we can add the `Mongo` instance to our application supervision tree:
+Finally, we can add the `Mongo.Repo` instance to our application supervision tree:
 
 ```elixir
   children = [
     # ...
-    {Mongo, MyApp.Repo.config()},
+    MyApp.Repo,
     # ...
   ]
 ```

--- a/lib/mongo/repo.ex
+++ b/lib/mongo/repo.ex
@@ -23,11 +23,11 @@ defmodule Mongo.Repo do
 
   For a complete list of configuration options take a look at `Mongo`.
 
-  Finally we can add the `Mongo` instance to our application supervision tree
+  Finally we can add the `Mongo.Repo` instance to our application supervision tree
 
       children = [
         # ...
-        {Mongo, MyApp.Repo.config()},
+        MyApp.Repo,
         # ...
       ]
 
@@ -58,6 +58,10 @@ defmodule Mongo.Repo do
         @otp_app
         |> Application.get_env(__MODULE__, [])
         |> Keyword.put_new(:name, @topology)
+      end
+
+      def child_spec(_opts) do
+        Mongo.child_spec(config())
       end
 
       unless @read_only do

--- a/test/mongo/repo_test.exs
+++ b/test/mongo/repo_test.exs
@@ -17,7 +17,7 @@ defmodule Mongo.RepoTest do
   end
 
   setup do
-    assert {:ok, pid} = start_supervised({Mongo, MyRepo.config()})
+    assert {:ok, pid} = start_supervised(MyRepo)
     Mongo.drop_database(pid, nil, w: 3)
     {:ok, [pid: pid]}
   end


### PR DESCRIPTION
To make it more convenient to add to an application's supervision tree, similar to how `Ecto.Repo`-based modules are typically added to the supervision tree.