### PR TITLE
Fix links to source code from documentation

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -50,7 +50,7 @@ defmodule Mongodb.Mixfile do
       ],
       main: "readme",
       source_url: @source_url,
-      source_ref: @version,
+      source_ref: "v#{@version}",
       formatters: ["html"]
     ]
   end


### PR DESCRIPTION
The project uses GitHub tags like v1.4.1 for `@version 1.4.1`, so correcting the `source_ref` makes for working links.

The `v#{@version}` pattern seems to be used by many projects (from a biased sample of what I happen to have in my disk at the moment).