### PR TITLE
Add missing decoder case for NaN

### DIFF
--- a/lib/bson/decoder.ex
+++ b/lib/bson/decoder.ex
@@ -190,6 +190,10 @@ defmodule BSON.DecoderGenerator do
         {:NaN, rest}
       end
 
+      defp type(@type_float, <<0, 0, 0, 0, 0, 0, 248::little-integer-size(8), 255::little-integer-size(8), rest::binary>>) do
+        {:NaN, rest}
+      end
+
       defp type(@type_float, <<1, 0, 0, 0, 0, 0, 240::little-integer-size(8), 127::little-integer-size(8), rest::binary>>) do
         {:NaN, rest}
       end


### PR DESCRIPTION
When running against our Mongo instance we got the following error:
```
%FunctionClauseError{module: BSON.Decoder, function: :type, arity: 2, kind: nil, args: nil, clauses: nil}
```

Turns out that, at least for our Mongo installation, this case is used for NaN. I have validated that the value is NaN in Mongo Compass and adding this case results in the document being deserialised to the same values as in Compass.