### PR TITLE
fix(master): ensure url_parser does not fail on missing txt record

### DIFF
--- a/lib/mongo/url_parser.ex
+++ b/lib/mongo/url_parser.ex
@@ -173,7 +173,7 @@ defmodule Mongo.UrlParser do
 
   defp resolve_txt_record(url_char) do
     case :inet_res.lookup(url_char, :in, :txt) do
-      [txt_record | _] ->
+      [[txt_record] | _] ->
         {:ok, txt_record}
 
       _other ->

--- a/lib/mongo/url_parser.ex
+++ b/lib/mongo/url_parser.ex
@@ -167,10 +167,12 @@ defmodule Mongo.UrlParser do
 
   defp resolve_srv_url(frags), do: frags
 
+  defp build_params(orig_options, nil) do
+    "#{orig_options}&ssl=true"
+  end
+
   defp build_params(orig_options, txt_record) do
-    [orig_options, txt_record, "ssl=true"]
-    |> Enum.filter(&(&1 != nil))
-    |> Enum.join("&")
+    "#{orig_options}&#{txt_record}&ssl=true"
   end
 
   defp resolve_txt_record(url_char) do

--- a/lib/mongo/url_parser.ex
+++ b/lib/mongo/url_parser.ex
@@ -165,6 +165,8 @@ defmodule Mongo.UrlParser do
     end
   end
 
+  defp resolve_srv_url(frags), do: frags
+
   defp build_params(orig_options, txt_record) do
     [orig_options, txt_record, "ssl=true"]
     |> Enum.filter(&(&1 != nil))
@@ -180,8 +182,6 @@ defmodule Mongo.UrlParser do
         {:ok, nil}
     end
   end
-
-  defp resolve_srv_url(frags), do: frags
 
   @spec get_host_srv([{term, term, term, term}]) :: {:ok, String.t()}
   defp get_host_srv(srv) when is_list(srv) do


### PR DESCRIPTION
Changes:

- use :inet_res.lookup instead of :inet_res.getbyname to prevent failures on missing txt records when resolving the connection string

The following code fixes issue #260 