### PR TITLE
Allow newer versions of decimal 2.x

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -33,7 +33,7 @@ defmodule Mongodb.Mixfile do
     [
       {:telemetry, "~> 1.0"},
       {:db_connection, "~> 2.6"},
-      {:decimal, "~> 2.1.1"},
+      {:decimal, "~> 2.1 and >= 2.1.1"},
       {:patch, "~> 0.12.0", only: [:dev, :test]},
       {:jason, "~> 1.3", only: [:dev, :test]},
       {:credo, "~> 1.7.0", only: [:dev, :test], runtime: false},


### PR DESCRIPTION
I've been keeping an override in a project to be able to upgrade `decimal`. Other dependencies related to Phoenix specify `~> 2.0`, but recently reading the Elixir forum I realized we can do better:

https://elixirforum.com/t/conflicting-dependencies-and-use-of-the-operator/68207/14?u=rhcarvalho