### PR TITLE
Add function `BSON.ObjectId.get_timestamp/1` and `BSON.ObjectId.get_timestamp!/1`

### DIFF
--- a/lib/bson/types.ex
+++ b/lib/bson/types.ex
@@ -142,6 +142,29 @@ defmodule BSON.ObjectId do
   defimpl String.Chars do
     def to_string(id), do: BSON.ObjectId.encode!(id)
   end
+
+  @doc """
+  Extracts timestamp from BSON.ObjectId
+  """
+  def get_timestamp!(%BSON.ObjectId{value: value}), do: do_get_timestamp(value)
+
+  def do_get_timestamp(<<ts::32, _::binary>>) do
+    DateTime.from_unix!(ts)
+  end
+
+  @doc """
+  Extracts timestamp from BSON.ObjectId
+
+  ## Examples
+      {:ok, timestamp} <- BSON.ObjectId.get_timestamp(id)
+  """
+  def get_timestamp(object_id) do
+    try do
+      {:ok, get_timestamp!(object_id)}
+    rescue
+      _ -> :error
+    end
+  end
 end
 
 defmodule BSON.Regex do

--- a/test/bson/types_test.exs
+++ b/test/bson/types_test.exs
@@ -11,6 +11,7 @@ defmodule BSON.TypesTest do
 
   @objectid %BSON.ObjectId{value: <<29, 32, 69, 244, 101, 119, 228, 28, 61, 24, 21, 215>>}
   @string "1d2045f46577e41c3d1815d7"
+  @timestamp DateTime.from_unix!(488_654_324)
 
   test "inspect BSON.ObjectId" do
     assert inspect(@objectid) == "#BSON.ObjectId<#{@string}>"
@@ -44,6 +45,21 @@ defmodule BSON.TypesTest do
 
   test "to_string BSON.ObjectId" do
     assert to_string(@objectid) == @string
+  end
+
+  test "BSON.ObjectId.get_timestamp!/1" do
+    value = BSON.ObjectId.get_timestamp!(@objectid)
+    assert DateTime.compare(value, @timestamp) == :eq
+
+    assert_raise FunctionClauseError, fn ->
+      BSON.ObjectId.get_timestamp!("")
+    end
+  end
+
+  test "BSON.ObjectId.get_timestamp/1" do
+    assert {:ok, value} = BSON.ObjectId.get_timestamp(@objectid)
+    assert DateTime.compare(value, @timestamp) == :eq
+    assert BSON.ObjectId.get_timestamp("") == :error
   end
 
   test "inspect BSON.Regex" do


### PR DESCRIPTION
Python and node.js mongodb libraries have helper functions to extract timestamp from `ObjectId`. The PR adds those missing helper functions.