### PR TITLE
Add support for directConnection setting in connection string.

### DIFF
--- a/lib/mongo/topology.ex
+++ b/lib/mongo/topology.ex
@@ -116,7 +116,7 @@ defmodule Mongo.Topology do
   # see https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst#configuration
   def init(opts) do
     seeds = Keyword.get(opts, :seeds, [seed(opts)])
-    type = Keyword.get(opts, :type, :unknown)
+    type = TopologyDescription.get_type(opts)
     set_name = Keyword.get(opts, :set_name, nil)
     local_threshold_ms = Keyword.get(opts, :local_threshold_ms, 15)
 

--- a/lib/mongo/topology_description.ex
+++ b/lib/mongo/topology_description.ex
@@ -175,6 +175,13 @@ defmodule Mongo.TopologyDescription do
     end
   end
 
+  def get_type(opts) do
+    case Keyword.get(opts, :direct_connection, false) do
+      true -> :single
+      false -> Keyword.get(opts, :type, :unknown)
+    end
+  end
+
   defp mongos_servers(%{:servers => servers}) do
     Enum.filter(servers, fn {_, server} -> server.type == :mongos end)
   end

--- a/lib/mongo/url_parser.ex
+++ b/lib/mongo/url_parser.ex
@@ -24,6 +24,7 @@ defmodule Mongo.UrlParser do
     "database" => :string,
     # Query options
     "replicaSet" => :string,
+    "directConnection" => ["true", "false"],
     "ssl" => ["true", "false"],
     "connectTimeoutMS" => :number,
     "socketTimeoutMS" => :number,

--- a/test/mongo/topology_description_test.exs
+++ b/test/mongo/topology_description_test.exs
@@ -123,13 +123,18 @@ defmodule Mongo.TopologyDescriptionTest do
     assert Enum.any?(all_hosts, fn sec -> sec == server end)
   end
 
-  test "Simplified server selection" do
-    single_server = "localhost:27017"
-
+  test "Set topology type to :single when direct_connection option is true" do
     opts = [
-      read_preference: %{mode: :secondary}
+      direct_connection: true
     ]
 
-    assert {:ok, {^single_server, _}} = TopologyDescription.select_servers(single(), :read, opts)
+    assert :single = TopologyDescription.get_type(opts)
+
+    opts = [
+      type: :unknown,
+      direct_connection: true
+    ]
+
+    assert :single = TopologyDescription.get_type(opts)
   end
 end

--- a/test/mongo/url_parser_test.exs
+++ b/test/mongo/url_parser_test.exs
@@ -228,5 +228,17 @@ defmodule Mongo.UrlParserTest do
                ]
              ]
     end
+
+    test "url with directConnection" do
+      for direct_connection <- ["true", "false"] do
+        assert UrlParser.parse_url(url: "mongodb://seed1.domain.com:27017/db_name?directConnection=#{direct_connection}") == [
+                 database: "db_name",
+                 direct_connection: String.to_atom(direct_connection),
+                 seeds: [
+                   "seed1.domain.com:27017"
+                 ]
+               ]
+      end
+    end
   end
 end


### PR DESCRIPTION
Support `directConnection` option in the MongoDB connection string options. Please review it. Thank you!

ref: https://www.mongodb.com/docs/manual/reference/connection-string-options/#mongodb-urioption-urioption.directConnection