### PR TITLE
Fix: Fix Object ID decoding logic for uppercase HEX string

### DIFF
--- a/lib/bson/types.ex
+++ b/lib/bson/types.ex
@@ -124,7 +124,7 @@ defmodule BSON.ObjectId do
     defp e(unquote(int)), do: unquote(char)
   end
 
-  for {char, int} <- Enum.with_index(?A..?F) do
+  for {char, int} <- Enum.with_index(?A..?F, 10) do
     defp d(unquote(char)), do: unquote(int)
   end
 

--- a/test/bson/types_test.exs
+++ b/test/bson/types_test.exs
@@ -11,6 +11,7 @@ defmodule BSON.TypesTest do
 
   @objectid %BSON.ObjectId{value: <<29, 32, 69, 244, 101, 119, 228, 28, 61, 24, 21, 215>>}
   @string "1d2045f46577e41c3d1815d7"
+  @string_uppercase "1D2045F46577E41C3D1815D7"
   @timestamp DateTime.from_unix!(488_654_324)
 
   test "inspect BSON.ObjectId" do
@@ -33,6 +34,14 @@ defmodule BSON.TypesTest do
 
   test "BSON.ObjectId.decode!/1" do
     assert BSON.ObjectId.decode!(@string) == @objectid
+
+    assert_raise FunctionClauseError, fn ->
+      BSON.ObjectId.decode!("")
+    end
+  end
+
+  test "BSON.ObjectId.decode!/1 for uppercase HEX" do
+    assert BSON.ObjectId.decode!(@string_uppercase) == @objectid
 
     assert_raise FunctionClauseError, fn ->
       BSON.ObjectId.decode!("")


### PR DESCRIPTION
prior tho this change `BSON.ObjectId.decode!/` was working incorrectly with uppercase hex strings.
It mapped A->0, B->1, C->2...F ->5
Instead of A->10, B->11... F->15
