### PR TITLE
Force increasing Range

### DIFF
--- a/lib/mongo/id_server.ex
+++ b/lib/mongo/id_server.ex
@@ -40,7 +40,7 @@ defmodule Mongo.IdServer do
 
   def handle_info(:reset_counters, last_reset) do
     new_reset = opposite_on_window(:calendar.universal_time())
-    :ets.insert(@name, gen_counters((last_reset + 1)..new_reset))
+    :ets.insert(@name, gen_counters((last_reset + 1)..new_reset//1))
     Process.send_after(self(), :reset_counters, @reset_timer)
 
     {:noreply, new_reset}


### PR DESCRIPTION
Keep the same behaviour as with earlier elixir versions.

Fix:
```
 warning: Range.new/2 and first..last default to a step of -1 when last < first. Use Range.new(first, last, -1) or first..last//-1, or pass 1 if that was your intention
  (mongodb_driver 1.5.2) lib/mongo/id_server.ex:43: Mongo.IdServer.handle_info/2
  (stdlib 6.2.2) gen_server.erl:2345: :gen_server.try_handle_info/3
  (stdlib 6.2.2) gen_server.erl:2433: :gen_server.handle_msg/6
  (stdlib 6.2.2) proc_lib.erl:329: :proc_lib.init_p_do_apply/3
```

Issue #271 

Be aware I wasn't able to run tests locally. I have MongoDB running locally, but the test suite doesn't connect to it, and I can't find instructions on how to do that.