### PR TITLE
Update session.ex add ServerSession.next_txn_num when ending the session to prevent silent no-write operation

### DIFF
--- a/lib/mongo/session.ex
+++ b/lib/mongo/session.ex
@@ -244,7 +244,8 @@ defmodule Mongo.Session do
   """
   @spec end_session(GenServer.server(), Session.t()) :: :ok | :error
   def end_session(topology_pid, session) do
-    with {:ok, session_server} <- call(session, :end_session) do
+    with {:ok, session_server} <- call(session, :end_session),
+    session_server <- ServerSession.next_txn_num(session_server) do
       Topology.checkin_session(topology_pid, session_server)
     end
   end


### PR DESCRIPTION
### Context:
I was testing the feature `Mongo.replace_one` with the enabled params : `upsert: true, retryable_writes: true` when I found out that none of my document was getting updated despite the change on the documents every time from an extract to next the very first attempt to replace_one.

### The digging
After some investigation I found that the issue was linked to the `retryable_writes` behaviour that was "using/re-using" the same sessions `lsid` and `txnNumber`.
From the documentation reusing the same `lsid` was supposed to be ok but not for `txnNumber`, I was surprised to discover that the `lsid` and `txnNumber` was staying exactly the same after multiple find_one followed by some minor change on the doc followed by an attempt to be `Mongo.replace_one` again. (the session_server was reused without increasing the `txnNumber`)


### Thanks
Big heads up to log feature: `log: &IO.inspect/1` that helped a start diagnose it even from a novice experience on the driver it self


I did some dummy test on own, and it solved my issue.
I may still have miss edge case so, Peers review will be very appreciated, I'm still very on the learning curve of the driver