### PR TITLE
[Fix] pass auth_db to detect auth mech

### DIFF
--- a/lib/mongo/auth.ex
+++ b/lib/mongo/auth.ex
@@ -17,7 +17,8 @@ defmodule Mongo.Auth do
           state
       end
 
-    case opts |> credentials() |> mechanism.auth(state.database, auth_state) do
+    auth_db = auth_state.database
+    case opts |> credentials() |> mechanism.auth(auth_db, auth_state) do
       :ok ->
         {:ok, state}
 


### PR DESCRIPTION
# Context
I was trying to connect to mongodb version > 4.0, it kept failing when passing auth_source: "admin".

# Issue
```mechanism.auth(state.database, auth_state)``` here we can see that auth_state is passed along with state.database e.g. app database. However, we want to check auth_mech agains auth database, therefore we need to change state.database to auth database. 