### PR TITLE
fix: do not negotiate TLS 1.3 when only TLS 1.2 ciphers are supplied

### DIFF
--- a/lib/mongo/mongo_db_connection.ex
+++ b/lib/mongo/mongo_db_connection.ex
@@ -168,9 +168,10 @@ defmodule Mongo.MongoDBConnection do
     # Do not set SNI for IP addresses
     ssl_opts =
       case :inet.parse_address(host) do
-        {:ok, _} -> opts[:ssl_opts]
+        {:ok, _} -> opts[:ssl_opts] || []
         _ -> Keyword.put_new(opts[:ssl_opts] || [], :server_name_indication, host)
       end
+      |> Utils.maybe_restrict_versions()
 
     case :ssl.connect(socket, ssl_opts, state.connect_timeout) do
       {:ok, ssl_sock} ->

--- a/lib/mongo_db_connection/utils.ex
+++ b/lib/mongo_db_connection/utils.ex
@@ -179,4 +179,54 @@ defmodule Mongo.MongoDBConnection.Utils do
         end
     end
   end
+
+  @tls13 :"tlsv1.3"
+
+  @doc """
+  Restricts TLS versions when the caller-supplied `:ciphers` are not compatible with TLS 1.3.
+
+  Erlang's `:ssl` does not automatically fall back from TLS 1.3 to TLS 1.2 when the configured
+  ciphers exclude TLS 1.3: it attempts TLS 1.3 negotiation, finds no compatible suite, and the
+  handshake fails. When the caller supplies `:ciphers` without an explicit `:versions`, this
+  function detects the TLS-1.2-only case and sets `:versions` to exclude TLS 1.3 so the
+  connection succeeds.
+  """
+  @spec maybe_restrict_versions(Keyword.t()) :: Keyword.t()
+  def maybe_restrict_versions(ssl_opts) do
+    with ciphers when is_list(ciphers) and ciphers != [] <- ssl_opts[:ciphers],
+         false <- Keyword.has_key?(ssl_opts, :versions),
+         supported = :ssl.versions()[:supported],
+         true <- @tls13 in supported,
+         tls13_ciphers = :ssl.cipher_suites(:exclusive, @tls13),
+         false <- any_cipher_match?(ciphers, tls13_ciphers) do
+      Logger.warning("restricting TLS versions to [:\"tlsv1.2\"] because supplied :ciphers do not include any TLS 1.3 suite")
+      Keyword.put(ssl_opts, :versions, [:"tlsv1.2"])
+    else
+      _ -> ssl_opts
+    end
+  end
+
+  defp any_cipher_match?(user_ciphers, tls13_ciphers) do
+    Enum.any?(user_ciphers, fn user_cipher ->
+      Enum.any?(tls13_ciphers, fn tls13_cipher ->
+        compare_ciphers(user_cipher, tls13_cipher)
+      end)
+    end)
+  end
+
+  defp compare_ciphers(c1, c2) do
+    s1 = to_cipher_charlist(c1)
+    s2 = to_cipher_charlist(c2)
+    s1 != nil and s1 == s2
+  end
+
+  # Normalize a cipher to a charlist for comparison. Returns an IANA-style
+  # charlist for known cipher shapes (charlist, binary, atom, map, tuple)
+  # via `:ssl.suite_to_str/1`, or `nil` if the value is not a recognizable
+  # cipher form. Callers must treat `nil` as "no match".
+  defp to_cipher_charlist(c) when is_list(c), do: c
+  defp to_cipher_charlist(c) when is_binary(c), do: String.to_charlist(c)
+  defp to_cipher_charlist(c) when is_atom(c), do: Atom.to_charlist(c)
+  defp to_cipher_charlist(c) when is_map(c) or is_tuple(c), do: :ssl.suite_to_str(c)
+  defp to_cipher_charlist(_), do: nil
 end

--- a/test/mongo_db_connection/utils_test.exs
+++ b/test/mongo_db_connection/utils_test.exs
@@ -1,0 +1,119 @@
+defmodule Mongo.MongoDBConnection.UtilsTest do
+  use ExUnit.Case, async: true
+
+  import ExUnit.CaptureLog
+
+  alias Mongo.MongoDBConnection.Utils
+
+  @tls13 :"tlsv1.3"
+  @tls13_supported @tls13 in :ssl.versions()[:supported]
+  @tls13_tag if @tls13_supported,
+               do: [requires_tls13: true],
+               else: [skip: "OTP build does not advertise TLS 1.3; cannot exercise fallback path"]
+
+  describe "maybe_restrict_versions/1" do
+    test "returns opts unchanged when no :ciphers are given" do
+      opts = [verify: :verify_peer]
+
+      log =
+        capture_log(fn ->
+          assert Utils.maybe_restrict_versions(opts) == opts
+        end)
+
+      refute log =~ "restricting"
+    end
+
+    test "returns opts unchanged when :ciphers is nil" do
+      opts = [ciphers: nil, verify: :verify_peer]
+
+      log =
+        capture_log(fn ->
+          assert Utils.maybe_restrict_versions(opts) == opts
+        end)
+
+      refute log =~ "restricting"
+    end
+
+    test "returns opts unchanged when :versions is already set" do
+      opts = [ciphers: [~c"AES256-SHA"], versions: [:"tlsv1.2"]]
+
+      log =
+        capture_log(fn ->
+          assert Utils.maybe_restrict_versions(opts) == opts
+        end)
+
+      refute log =~ "restricting"
+    end
+
+    @tag @tls13_tag
+    test "restricts versions to [:\"tlsv1.2\"] for a TLS-1.2-only cipher (charlist)" do
+      opts = [ciphers: [~c"AES256-SHA"]]
+
+      {result, log} = with_log(fn -> Utils.maybe_restrict_versions(opts) end)
+
+      assert result[:versions] == [:"tlsv1.2"]
+      assert log =~ "restricting TLS versions"
+    end
+
+    @tag @tls13_tag
+    test "restricts versions for a TLS-1.2-only cipher given as atom" do
+      opts = [ciphers: [:"AES256-SHA"]]
+
+      {result, log} = with_log(fn -> Utils.maybe_restrict_versions(opts) end)
+
+      assert result[:versions] == [:"tlsv1.2"]
+      assert log =~ "restricting TLS versions"
+    end
+
+    test "returns opts unchanged when :ciphers is an empty list" do
+      opts = [ciphers: [], verify: :verify_peer]
+
+      log =
+        capture_log(fn ->
+          assert Utils.maybe_restrict_versions(opts) == opts
+        end)
+
+      refute log =~ "restricting"
+    end
+
+    @tag @tls13_tag
+    test "leaves opts untouched when a TLS 1.3 cipher (map form) is present" do
+      [tls13_suite | _] = :ssl.cipher_suites(:exclusive, @tls13)
+      opts = [ciphers: [tls13_suite]]
+
+      log =
+        capture_log(fn ->
+          assert Utils.maybe_restrict_versions(opts) == opts
+        end)
+
+      refute log =~ "restricting"
+    end
+
+    @tag @tls13_tag
+    test "leaves opts untouched when a TLS 1.3 cipher is given as a binary IANA name" do
+      [tls13_suite | _] = :ssl.cipher_suites(:exclusive, @tls13)
+      iana_binary = tls13_suite |> :ssl.suite_to_str() |> to_string()
+      opts = [ciphers: [iana_binary]]
+
+      log =
+        capture_log(fn ->
+          assert Utils.maybe_restrict_versions(opts) == opts
+        end)
+
+      refute log =~ "restricting"
+    end
+
+    @tag @tls13_tag
+    test "leaves opts untouched when ciphers mix TLS 1.2 and TLS 1.3 suites" do
+      [tls13_suite | _] = :ssl.cipher_suites(:exclusive, @tls13)
+      opts = [ciphers: [~c"AES256-SHA", tls13_suite]]
+
+      log =
+        capture_log(fn ->
+          assert Utils.maybe_restrict_versions(opts) == opts
+        end)
+
+      refute log =~ "restricting"
+    end
+  end
+end


### PR DESCRIPTION
When the caller passes `ssl_opts.ciphers` without an explicit `ssl_opts.versions`, Erlang's `:ssl` will still attempt TLS 1.3 negotiation if the OTP build supports it. If none of the supplied ciphers match a TLS 1.3 suite, the handshake fails with no automatic fallback to TLS 1.2.

In practice this surfaces when the MongoDB server starts negotiating TLS 1.3 (e.g. after a cluster upgrade) and the user's `:ciphers` list only contains TLS-1.2-era suites.

`Mongo.MongoDBConnection.Utils.maybe_restrict_versions/1` detects the mismatch and pins `:versions` to `[:"tlsv1.2"]` when the supplied ciphers do not include any TLS 1.3 suite. Callers who explicitly set `:versions` are left untouched. The override is logged at `Logger.warning` so operators see it in production where info-level logs are typically filtered.

Also normalizes `opts[:ssl_opts]` to `[]` on the IP-address branch of `defp ssl/2`; previously that branch could pass `nil` to `:ssl.connect/3` if the caller omitted `:ssl_opts`.

Unit tests cover charlist / atom / binary / map cipher shapes, mixed TLS 1.2 + TLS 1.3 lists, and the no-op cases (`:ciphers` nil/empty, `:versions` already set).